### PR TITLE
Added pruning for . and ..

### DIFF
--- a/subdir/subdir.m
+++ b/subdir/subdir.m
@@ -101,8 +101,8 @@ end
 % Prune . and ..
 %---------------------------
 [~, ~, tail] = cellfun(@fileparts, {Files(:).name}, 'UniformOutput', false);
-dottest = cellfun(@isempty, tail);
-Files(~dottest & [Files(:).isdir]) = [];
+dottest = cellfun(@(x) isempty(regexp(x, '\.+(\w+$)', 'once')), tail);
+Files(dottest & [Files(:).isdir]) = [];
 
 %---------------------------
 % Output

--- a/subdir/subdir.m
+++ b/subdir/subdir.m
@@ -98,6 +98,13 @@ for ifolder = 1:length(pathfolders)
 end
 
 %---------------------------
+% Prune . and ..
+%---------------------------
+[~, ~, tail] = cellfun(@fileparts, {Files(:).name}, 'UniformOutput', false);
+dottest = cellfun(@isempty, tail);
+Files(~dottest & [Files(:).isdir]) = [];
+
+%---------------------------
 % Output
 %---------------------------
     


### PR DESCRIPTION
When calling `subdir` with no input arguments we get a tree of the current directory. Since this tree is generated using recursive `dir` calls, if there are a lot of nested subfolders we obtain a lot of `.` and `..` 'directory' entries.

For example, if we run the following code in an empty directory:

```
mkdir('test1/test2');
subdir;
```

We receive the following command window output:

```
C:\test\.
C:\test\..
C:\test\test1
C:\test\test1\.
C:\test\test1\..
C:\test\test1\test2
C:\test\test1\test2\.
C:\test\test1\test2\..
```

If we incorporate the mod, we receive the following command window output:

```
C:\test\test1
C:\test\test1\test2
```
